### PR TITLE
add support for base catalog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,12 @@
                         {{ branch }}
                     </option>
                 </select>
+                <select id="base-list-select" v-model="selectedBase" @change="selectBase()">
+                    <option disabled value="">base branch</option>
+                    <option v-for="base in branchesWithNone" v-if="base !== selectedBranch">
+                        {{ base }}
+                    </option>
+                </select>
                 <select id="catalog-list-select" v-model="selectedCatalog" @change="selectCatalog()">
                     <option disabled value="">select catalog</option>
                     <option v-for="catalog in catalogs">

--- a/settings.ini
+++ b/settings.ini
@@ -7,6 +7,11 @@ node-red:
       - packages/node_modules/@node-red/editor-client/locales
       - packages/node_modules/@node-red/runtime/locales
       - packages/node_modules/@node-red/nodes/locales
+    master:
+      paths:
+      - packages/node_modules/@node-red/editor-client/locales
+      - packages/node_modules/@node-red/runtime/locales
+      - packages/node_modules/@node-red/nodes/locales
 node-red-dashboard:
   url: https://github.com/node-red/node-red-dashboard.git
   branches:


### PR DESCRIPTION
As reported by https://github.com/node-red/i18n-viewer/issues/2, **i18n-viewer** do not provide means for knowing changes on base `en-US` message catalogues.
This PR adds feature to specify base `en-US` branch that can be used to compare to target branch.

![スクリーンショット 2019-08-11 18 23 06](https://user-images.githubusercontent.com/30289092/62832144-203b8080-bc65-11e9-82b0-1145df05d02a.png)
